### PR TITLE
Update to latest version of @opendocsg/pdf2md

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,14 @@
     "jsdom-global": "^3.0.2",
     "mocha": "^8.2.1",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-    "pdf2md": "https://github.com/akaalias/pdf2md",
     "rollup": "^2.35.1",
     "ts-node": "^9.1.1",
     "tslib": "^1.14.1",
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@opendocsg/pdf2md": "git+https://github.com/akaalias/pdf2md.git",
+    "@opendocsg/pdf2md": "^0.1.21",
     "electron": "^10.2.0",
-    "patch-package": "^6.2.2"
-  },
-  "postinstall": "npx patch-package"
+    "pdfjs-dist": "^2.6.347"
+  }
 }

--- a/src/additionalTypes.d.ts
+++ b/src/additionalTypes.d.ts
@@ -1,5 +1,3 @@
-declare module 'node_modules/pdf2md/lib/pdf2md';
-declare module 'node_modules/pdf2md/lib/util/pdf';
-declare module 'node_modules/pdf2md/lib/util/transformations';
-declare module 'node_modules/pdf2md/node_modules/pdfjs-dist/build/pdf';
-declare module 'node_modules/pdf2md/node_modules/pdfjs-dist/build/pdf.worker.entry';
+declare module '@opendocsg/pdf2md';
+declare module 'pdfjs-dist/es5/build/pdf';
+declare module 'pdfjs-dist/es5/build/pdf.worker.entry';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import {Plugin, addIcon, Notice, Modal, App} from "obsidian"
-import {parse} from 'node_modules/pdf2md/lib/util/pdf';
-import {makeTransformations, transform} from 'node_modules/pdf2md/lib/util/transformations';
-import pdfjs from 'node_modules/pdf2md/node_modules/pdfjs-dist/build/pdf';
-import worker from 'node_modules/pdf2md/node_modules/pdfjs-dist/build/pdf.worker.entry';
+import * as pdf2md from '@opendocsg/pdf2md'
+// @opendocsg/pdf2md uses the ES5 build of pdfjs-dist.
+// We want to explicitly set the worker for the module,
+// so bring these in as modules
+import pdfjs from 'pdfjs-dist/es5/build/pdf';
+import worker from 'pdfjs-dist/es5/build/pdf.worker.entry';
 
 import ExtractPDFSettings from "./ExtractPDFSettings";
 import ExtractPDFSettingsTab from "./ExtractPDFSettingsTab";
@@ -51,15 +53,7 @@ export default class ExtractPDFPlugin extends Plugin {
 
 		pdfjs.GlobalWorkerOptions.workerSrc = worker;
 
-		let doc = await pdfjs.getDocument(arrayBuffer).promise;
-		var result = await parse(doc);
-		const {fonts, pages} = result
-		const transformations = makeTransformations(fonts.map)
-		const parseResult = transform(pages, transformations)
-		const resultMD = parseResult.pages
-			// @ts-ignore
-			.map(page => page.items.join('\n'))
-			.join('---\n\n')
+		const resultMD = await pdf2md(arrayBuffer)
 
 		const filePath = file.name.replace(".pdf", ".md");
 


### PR DESCRIPTION
v0.1.21 of @opendocsg/pdf2md uses the latest version of pdfjs-dist
and adjusts its codebase to lineup with changes to the PDF.js API.
Drop this into obsidian-extract-pdf so that the project no longer
needs to maintain its own fork of pdf2md.

- Consolidate pdf2md dependencies to the official one
- Explicitly bring in pdfjs-dist
- Change codebase so that we just call pdf2md to get the Markdown text,
  rather than copy its implementation
- Adjust module declarations to pick up the new dependencies,relying
  on TypeScript's module resolution to look inside node_modules